### PR TITLE
Fix incorrect logo shape example

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,7 +171,7 @@
             ["----RuRu", "Half rectangle"],
             ["CgScScCg", "Circles and stars mixed"],
             ["RpRpRpRp:CwCwCwCw", "Layering example"],
-            ["CuRw--Rw:----Cu--", "Logo Shape"],
+            ["CuRw--Rw:----Ru--", "Logo Shape"],
           ];
           for (let i = 0; i < examples.length; ++i) {
             const [key, desc] = examples[i];


### PR DESCRIPTION
Logo shape is gray rectangle on top layer, not gray circle.